### PR TITLE
Fix: Adiciona referências CSS/JS e usings para Radzen Blazor

### DIFF
--- a/EstudoIA/EstudoIA/Components/App.razor
+++ b/EstudoIA/EstudoIA/Components/App.razor
@@ -7,6 +7,7 @@
     <base href="/" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["EstudoIA.styles.css"]" />
+    <link rel="stylesheet" href="_content/Radzen.Blazor/css/material-base.css">
     <ImportMap />
     <HeadOutlet />
 </head>
@@ -14,6 +15,7 @@
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
 </body>
 
 </html>

--- a/EstudoIA/EstudoIA/Components/_Imports.razor
+++ b/EstudoIA/EstudoIA/Components/_Imports.razor
@@ -9,3 +9,5 @@
 @using EstudoIA
 @using EstudoIA.Client
 @using EstudoIA.Components
+@using Radzen
+@using Radzen.Blazor


### PR DESCRIPTION
- Modifica App.razor para incluir o link do tema CSS do Radzen e o script Radzen.Blazor.js.
- Adiciona @using Radzen e @using Radzen.Blazor ao _Imports.razor principal.

Estas alterações visam corrigir problemas de estilo e funcionalidade dos componentes Radzen.