### PR TITLE
Refatorar UI para Blazor puro e HTML

### DIFF
--- a/EstudoIA/EstudoIA/Components/App.razor
+++ b/EstudoIA/EstudoIA/Components/App.razor
@@ -7,7 +7,7 @@
     <base href="/" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["EstudoIA.styles.css"]" />
-    <link rel="stylesheet" href="_content/Radzen.Blazor/css/material-base.css">
+    <!-- Link CSS Radzen removido -->
     <ImportMap />
     <HeadOutlet />
 </head>
@@ -15,7 +15,7 @@
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
-    <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
+    <!-- Script JS Radzen removido -->
 </body>
 
 </html>

--- a/EstudoIA/EstudoIA/Components/_Imports.razor
+++ b/EstudoIA/EstudoIA/Components/_Imports.razor
@@ -9,5 +9,4 @@
 @using EstudoIA
 @using EstudoIA.Client
 @using EstudoIA.Components
-@using Radzen
-@using Radzen.Blazor
+@* Usings Radzen removidos *@

--- a/EstudoIA/EstudoIA/Pages/Pessoas/ListarPessoas.razor
+++ b/EstudoIA/EstudoIA/Pages/Pessoas/ListarPessoas.razor
@@ -1,33 +1,63 @@
 @page "/listar-pessoas"
-@using EstudoIA.Domain.Entities // Ajustado
-@using Radzen
-@using Radzen.Blazor
-@using EstudoIA.Pages.Pessoas // Namespace para o code-behind
+@using EstudoIA.Domain.Entities
+@using EstudoIA.Pages.Pessoas
 
 @inherits ListarPessoasBase
 
 <PageTitle>Pessoas Cadastradas</PageTitle>
 
-<RadzenText Text="Pessoas Cadastradas" TextStyle="TextStyle.H3" TagName="TagName.H1" Class="mt-4" />
+<h3>Pessoas Cadastradas</h3>
 
-<RadzenButton Text="Adicionar Nova Pessoa" Click="@NavigateToCadastrarPessoa" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Primary" Class="mt-3 mb-4" />
+<button class="btn btn-primary my-3" @onclick="NavigateToCadastrarPessoa">Adicionar Nova Pessoa</button>
 
-<RadzenDataGrid @ref="grid" AllowFiltering="true" AllowPaging="true" PageSize="10" AllowSorting="true"
-                Data="@pessoas" TItem="Pessoa" ColumnWidth="200px" EmptyText="Nenhuma pessoa cadastrada.">
-    <Columns>
-        <RadzenDataGridColumn TItem="Pessoa" Property="Nome" Title="Nome" />
-        <RadzenDataGridColumn TItem="Pessoa" Property="DataNascimento" Title="Data de Nascimento">
-            <Template Context="pessoa">
-                @($"{pessoa.DataNascimento:dd/MM/yyyy}")
-            </Template>
-        </RadzenDataGridColumn>
-        <RadzenDataGridColumn TItem="Pessoa" Property="Email" Title="E-mail" />
-        <RadzenDataGridColumn TItem="Pessoa" Property="Cpf" Title="CPF" />
-        <RadzenDataGridColumn TItem="Pessoa" Title="Ações" Width="160px" Sortable="false" Filterable="false" TextAlign="TextAlign.Center">
-            <Template Context="pessoa">
-                <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light" Class="m-1" Click="@(args => NavigateToEditarPessoa(pessoa.Id))" @onclick:stopPropagation />
-                <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Class="m-1" Click="@(args => ConfirmDeletePessoa(pessoa.Id, pessoa.Nome))" @onclick:stopPropagation />
-            </Template>
-        </RadzenDataGridColumn>
-    </Columns>
-</RadzenDataGrid>
+@if (!string.IsNullOrEmpty(successMessage))
+{
+    <div class="alert alert-success" role="alert">
+        @successMessage
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @errorMessage
+    </div>
+}
+
+@if (pessoas == null)
+{
+    <p><em>Carregando...</em></p>
+}
+else if (!pessoas.Any())
+{
+    <p>Nenhuma pessoa cadastrada.</p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Nome</th>
+                <th>Data de Nascimento</th>
+                <th>E-mail</th>
+                <th>CPF</th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var pessoa in pessoas)
+            {
+                <tr>
+                    <td>@pessoa.Nome</td>
+                    <td>@pessoa.DataNascimento.ToString("dd/MM/yyyy")</td>
+                    <td>@pessoa.Email</td>
+                    <td>@pessoa.Cpf</td>
+                    <td>
+                        <button class="btn btn-sm btn-outline-primary me-1" @onclick="() => NavigateToEditarPessoa(pessoa.Id)">Editar</button>
+                        <button class="btn btn-sm btn-outline-danger" @onclick="() => ConfirmDeletePessoa(pessoa.Id, pessoa.Nome)">Excluir</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/EstudoIA/EstudoIA/Pages/Pessoas/SalvarPessoa.razor
+++ b/EstudoIA/EstudoIA/Pages/Pessoas/SalvarPessoa.razor
@@ -1,65 +1,52 @@
 @page "/cadastrar-pessoa"
 @page "/editar-pessoa/{PessoaId:guid}"
 
-@using EstudoIA.Domain.Entities // Ajustado
-@using Radzen
-@using Radzen.Blazor
 @using System.ComponentModel.DataAnnotations
-@using EstudoIA.Pages.Pessoas // Namespace para o code-behind e PessoaModel
+@using EstudoIA.Pages.Pessoas
 
 @inherits SalvarPessoaBase
 
-<PageTitle>@(IsEditMode ? "Editar Pessoa" : "Cadastrar Nova Pessoa")</PageTitle>
+<PageTitle>@PageTitle</PageTitle>
 
-<RadzenText Text="@(IsEditMode ? "Editar Pessoa" : "Cadastrar Nova Pessoa")" TextStyle="TextStyle.H3" TagName="TagName.H1" Class="mt-4 mb-4" />
+<h3>@PageTitle</h3>
 
-<RadzenTemplateForm TItem="PessoaModel" Data="@pessoaModel" Submit="@OnSubmit" InvalidSubmit="@OnInvalidSubmit">
-    <RadzenFieldset Text="Dados Pessoais">
-        <div class="row mb-3">
-            <div class="col-md-3 align-items-center d-flex">
-                <RadzenLabel Text="Nome" Component="Nome" />
-            </div>
-            <div class="col-md-9">
-                <RadzenTextBox @bind-Value="pessoaModel.Nome" Name="Nome" Class="w-100" />
-                <RadzenRequiredValidator Component="Nome" Text="Nome é obrigatório" Popup="true" Style="position: absolute" />
-            </div>
+<EditForm Model="@pessoaModel" OnValidSubmit="HandleValidSubmit" OnInvalidSubmit="HandleInvalidSubmit">
+    <DataAnnotationsValidator />
+
+    @if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div class="alert alert-danger" role="alert">
+            @errorMessage
         </div>
+    }
+    @* <ValidationSummary /> @* Pode ser usado para um resumo de todos os erros *@
 
-        <div class="row mb-3">
-            <div class="col-md-3 align-items-center d-flex">
-                <RadzenLabel Text="Data de Nascimento" Component="DataNascimento" />
-            </div>
-            <div class="col-md-9">
-                <RadzenDatePicker @bind-Value="pessoaModel.DataNascimento" Name="DataNascimento" DateFormat="dd/MM/yyyy" Class="w-100" />
-                <RadzenRequiredValidator Component="DataNascimento" Text="Data de Nascimento é obrigatória" Popup="true" Style="position: absolute" />
-            </div>
-        </div>
+    <div class="mb-3">
+        <label for="nome" class="form-label">Nome:</label>
+        <InputText id="nome" class="form-control" @bind-Value="pessoaModel.Nome" />
+        <ValidationMessage For="@(() => pessoaModel.Nome)" />
+    </div>
 
-        <div class="row mb-3">
-            <div class="col-md-3 align-items-center d-flex">
-                <RadzenLabel Text="E-mail" Component="Email" />
-            </div>
-            <div class="col-md-9">
-                <RadzenTextBox @bind-Value="pessoaModel.Email" Name="Email" Class="w-100" />
-                <RadzenRequiredValidator Component="Email" Text="E-mail é obrigatório" Popup="true" Style="position: absolute" />
-                <RadzenEmailValidator Component="Email" Text="Formato de e-mail inválido" Popup="true" Style="position: absolute" />
-            </div>
-        </div>
+    <div class="mb-3">
+        <label for="dataNascimento" class="form-label">Data de Nascimento:</label>
+        <InputDate id="dataNascimento" class="form-control" @bind-Value="pessoaModel.DataNascimento" />
+        <ValidationMessage For="@(() => pessoaModel.DataNascimento)" />
+    </div>
 
-        <div class="row mb-3">
-            <div class="col-md-3 align-items-center d-flex">
-                <RadzenLabel Text="CPF" Component="Cpf" />
-            </div>
-            <div class="col-md-9">
-                <RadzenTextBox @bind-Value="pessoaModel.Cpf" Name="Cpf" Class="w-100" />
-                <RadzenRequiredValidator Component="Cpf" Text="CPF é obrigatório" Popup="true" Style="position: absolute" />
-                @* Adicionar validador de CPF customizado se necessário *@
-            </div>
-        </div>
-    </RadzenFieldset>
+    <div class="mb-3">
+        <label for="email" class="form-label">E-mail:</label>
+        <InputText id="email" type="email" class="form-control" @bind-Value="pessoaModel.Email" />
+        <ValidationMessage For="@(() => pessoaModel.Email)" />
+    </div>
 
-    <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="1rem" Class="mt-4">
-        <RadzenButton ButtonType="ButtonType.Submit" Text="Salvar" Icon="save" ButtonStyle="ButtonStyle.Primary" />
-        <RadzenButton Text="Cancelar" Icon="cancel" ButtonStyle="ButtonStyle.Light" Click="@NavigateToListarPessoas" />
-    </RadzenStack>
-</RadzenTemplateForm>
+    <div class="mb-3">
+        <label for="cpf" class="form-label">CPF:</label>
+        <InputText id="cpf" class="form-control" @bind-Value="pessoaModel.Cpf" />
+        <ValidationMessage For="@(() => pessoaModel.Cpf)" />
+    </div>
+
+    <div class="mt-4">
+        <button type="submit" class="btn btn-success">@SubmitButtonText</button>
+        <button type="button" class="btn btn-outline-secondary ms-2" @onclick="NavigateToListarPessoas">Cancelar</button>
+    </div>
+</EditForm>

--- a/EstudoIA/EstudoIA/Pages/Pessoas/SalvarPessoa.razor.cs
+++ b/EstudoIA/EstudoIA/Pages/Pessoas/SalvarPessoa.razor.cs
@@ -2,15 +2,13 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using EstudoIA.Application.Services; // Ajustado
-using EstudoIA.Domain.Entities;      // Ajustado
-using Radzen;
+using EstudoIA.Application.Services;
+// Removido: using EstudoIA.Domain.Entities; // PessoaModel está agora neste arquivo
+// Removido: using Radzen; // Não mais necessário
 
-// O namespace aqui deve corresponder ao local do arquivo dentro do projeto Blazor principal.
 namespace EstudoIA.Pages.Pessoas
 {
-    // Modelo auxiliar para o formulário, incluindo DataAnnotations para validação do Radzen
-    public class PessoaModel
+    public class PessoaModel // Mantido o PessoaModel para validação com DataAnnotations
     {
         public Guid Id { get; set; }
 
@@ -18,7 +16,7 @@ namespace EstudoIA.Pages.Pessoas
         public string Nome { get; set; }
 
         [Required(ErrorMessage = "Data de Nascimento é obrigatória")]
-        [Range(typeof(DateTime), "1/1/1900", "1/1/2100", ErrorMessage = "Data de Nascimento inválida")]
+        [Range(typeof(DateTime), "1/1/1900", "1/1/2100", ErrorMessage = "Data de Nascimento inválida. Use dd/mm/aaaa e entre 01/01/1900 e 01/01/2100.")]
         public DateTime? DataNascimento { get; set; }
 
         [Required(ErrorMessage = "E-mail é obrigatório")]
@@ -26,6 +24,8 @@ namespace EstudoIA.Pages.Pessoas
         public string Email { get; set; }
 
         [Required(ErrorMessage = "CPF é obrigatório")]
+        // TODO: Adicionar uma validação customizada para CPF (formato e lógica)
+        // Exemplo: [RegularExpression(@"^\d{3}\.\d{3}\.\d{3}-\d{2}$", ErrorMessage = "Formato de CPF inválido (###.###.###-##)")]
         public string Cpf { get; set; }
 
         public PessoaModel()
@@ -45,15 +45,22 @@ namespace EstudoIA.Pages.Pessoas
         [Inject]
         protected NavigationManager NavigationManager { get; set; }
 
-        [Inject]
-        protected NotificationService NotificationService { get; set; }
+        // Removido: NotificationService, pois não usaremos mais o do Radzen.
+        // As mensagens de erro/sucesso serão tratadas de forma mais simples.
 
         protected PessoaModel pessoaModel = new PessoaModel();
         protected bool IsEditMode => PessoaId.HasValue && PessoaId.Value != Guid.Empty;
-        protected string ErrorMessage { get; set; }
+        protected string PageTitle => IsEditMode ? "Editar Pessoa" : "Cadastrar Nova Pessoa";
+        protected string SubmitButtonText => IsEditMode ? "Salvar Alterações" : "Cadastrar Pessoa";
+
+        protected string errorMessage;
+        protected string successMessage;
 
         protected override async Task OnParametersSetAsync()
         {
+            errorMessage = null;
+            successMessage = null;
+
             if (IsEditMode)
             {
                 try
@@ -72,67 +79,73 @@ namespace EstudoIA.Pages.Pessoas
                     }
                     else
                     {
-                        NotificationService.Notify(NotificationSeverity.Error, "Erro", $"Pessoa com ID {PessoaId.Value} não encontrada.");
-                        NavigateToListarPessoas();
+                        errorMessage = $"Pessoa com ID {PessoaId.Value} não encontrada.";
+                        // Opcional: redirecionar se não encontrado em modo de edição
+                        // NavigateToListarPessoas();
                     }
                 }
                 catch (Exception ex)
                 {
-                    NotificationService.Notify(NotificationSeverity.Error, "Erro ao carregar pessoa", ex.Message, 5000);
-                    NavigateToListarPessoas();
+                    errorMessage = $"Erro ao carregar pessoa: {ex.Message}";
                 }
             }
             else
             {
                 pessoaModel = new PessoaModel();
             }
-            await base.OnParametersSetAsync(); // Adicionado para garantir ciclo de vida
+            await base.OnParametersSetAsync();
         }
 
-        protected async Task OnSubmit()
+        protected async Task HandleValidSubmit()
         {
-            ErrorMessage = null;
+            errorMessage = null;
+            successMessage = null;
+
             try
             {
                 if (!pessoaModel.DataNascimento.HasValue)
                 {
-                    NotificationService.Notify(NotificationSeverity.Error, "Erro de Validação", "Data de Nascimento é obrigatória.", 5000);
+                    // Esta validação já deve ser coberta pelo [Required] e DataAnnotationsValidator
+                    // mas uma dupla checagem não faz mal se houver dúvidas.
+                    errorMessage = "Data de Nascimento é obrigatória.";
                     return;
                 }
 
                 if (IsEditMode)
                 {
                     PessoaService.UpdatePessoa(pessoaModel.Id, pessoaModel.Nome, pessoaModel.DataNascimento.Value, pessoaModel.Email, pessoaModel.Cpf);
-                    NotificationService.Notify(NotificationSeverity.Success, "Sucesso", "Pessoa atualizada com sucesso!", 3000);
+                    // successMessage = "Pessoa atualizada com sucesso!"; // Pode ser melhor redirecionar e mostrar na lista
+                    NavigationManager.NavigateTo("/listar-pessoas", forceLoad: true); // forceLoad para garantir que a lista recarregue com a mensagem de outra página (se houver)
                 }
                 else
                 {
                     PessoaService.CreatePessoa(pessoaModel.Nome, pessoaModel.DataNascimento.Value, pessoaModel.Email, pessoaModel.Cpf);
-                    NotificationService.Notify(NotificationSeverity.Success, "Sucesso", "Pessoa cadastrada com sucesso!", 3000);
+                    // successMessage = "Pessoa cadastrada com sucesso!";
+                    NavigationManager.NavigateTo("/listar-pessoas", forceLoad: true);
                 }
-                NavigateToListarPessoas();
+                // Após salvar, normalmente redirecionamos para a lista.
+                // A mensagem de sucesso pode ser passada via query string ou um serviço de estado simples se necessário.
+                // Por simplicidade, vamos apenas redirecionar. A lista pode ter sua própria mensagem ao carregar.
             }
             catch (InvalidOperationException ex)
             {
-                ErrorMessage = ex.Message;
-                NotificationService.Notify(NotificationSeverity.Error, "Erro de Negócio", ex.Message, 5000);
+                errorMessage = ex.Message; // Ex: CPF duplicado
             }
             catch (ArgumentException ex)
             {
-                 ErrorMessage = ex.Message;
-                 NotificationService.Notify(NotificationSeverity.Error, "Erro de Validação", ex.Message, 5000);
+                 errorMessage = ex.Message; // Ex: Validação da entidade
             }
             catch (Exception ex)
             {
-                ErrorMessage = $"Ocorreu um erro inesperado: {ex.Message}";
-                NotificationService.Notify(NotificationSeverity.Error, "Erro Inesperado", ErrorMessage, 5000);
+                errorMessage = $"Ocorreu um erro inesperado: {ex.Message}";
             }
-            await InvokeAsync(StateHasChanged);
+            StateHasChanged(); // Atualiza a UI para mostrar mensagens de erro, se houver
         }
 
-        protected void OnInvalidSubmit()
+        protected void HandleInvalidSubmit()
         {
-            NotificationService.Notify(NotificationSeverity.Warning, "Atenção", "Por favor, corrija os erros de validação.", 4000);
+            errorMessage = "Por favor, corrija os erros de validação.";
+            successMessage = null;
         }
 
         protected void NavigateToListarPessoas()

--- a/EstudoIA/EstudoIA/Program.cs
+++ b/EstudoIA/EstudoIA/Program.cs
@@ -3,7 +3,7 @@ using EstudoIA.Application.Services; // Novo: Para PessoaService
 using EstudoIA.Domain.Interfaces;    // Novo: Para IPessoaRepository
 using EstudoIA.Infrastructure.Repositories; // Novo: Para PessoaRepository (concreto)
 using EstudoIA.Infrastructure.Adapters;   // Novo: Para PessoaRepositoryAdapter
-using Radzen; // Novo: Para serviços Radzen como DialogService, NotificationService
+// Radzen using removido
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,11 +12,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 
-// Adicionar serviços Radzen (se ainda não estiverem presentes)
-builder.Services.AddScoped<DialogService>();
-builder.Services.AddScoped<NotificationService>();
-builder.Services.AddScoped<TooltipService>(); // Exemplo de outros serviços Radzen
-builder.Services.AddScoped<ContextMenuService>(); // Exemplo de outros serviços Radzen
+// Registros de serviços Radzen removidos
 
 
 // Nossos serviços da aplicação de Pessoa


### PR DESCRIPTION
- Remove todas as dependências e referências aos componentes Radzen.Blazor.
- Reescreve as páginas ListarPessoas e SalvarPessoa (arquivos .razor e .razor.cs) utilizando componentes Blazor padrão (EditForm, InputText, etc.) e HTML.
- Implementa confirmação de exclusão usando IJSRuntime e o confirm() do navegador.
- Lógica de validação mantida com DataAnnotations e componentes de validação Blazor.
- Remove configurações e serviços Radzen do Program.cs, App.razor e _Imports.razor.